### PR TITLE
NTBS-1441 Fix wrong filtering of legacy cases in search

### DIFF
--- a/ntbs-service/Services/LegacySearchBuilder.cs
+++ b/ntbs-service/Services/LegacySearchBuilder.cs
@@ -137,7 +137,7 @@ namespace ntbs_service.Services
         private void AppendCondition(string condition) 
         {
             sqlQuery += $@"
-                AND {condition}";
+                AND ({condition})";
         }
     }
 }


### PR DESCRIPTION
The lack of parenthesis in the correct place for the search parameters meant that in a situation where:
- an LTBR record, say 123-1 was imported ...
- ... and correctly marked as imported in the migration db
- by searching for id '123-1' the legacy record would (correctly) not show up
- but by searching for id '123' both the imported and the legacy record would be returned

